### PR TITLE
Add Rust to languages.json

### DIFF
--- a/src/configs/languages.json
+++ b/src/configs/languages.json
@@ -44,6 +44,11 @@
 		"shortName": "Go",
 		"background": "#00A7D1"
 	},
+	"Rust": {
+		"name": "Rust",
+		"shortName": "RS",
+		"background": "#B94700"
+	},	
 	"Other": {
 		"name": "Other",
 		"shortName": "O",


### PR DESCRIPTION
Since Rust is now one of the ZTM courses, it would be good to support it for submissions for AOC. I am hoping this is all that is needed.